### PR TITLE
Made sure staff type components could be seen

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -69,11 +69,11 @@ module.exports = (pool) => {
     try {
       const { 
         name, role, ssn, birthdate, sex, address, 
-        supervisorID, username, password
+        supervisorID, username, password, stafftype
       } = req.body;
       
       // Validate input
-      if (!name || !role || !ssn || !birthdate || !sex || !address || !username || !password) {
+      if (!name || !role || !ssn || !birthdate || !sex || !address || !username || !password || !stafftype) {
         return res.status(400).json({ error: 'All required fields must be provided' });
       }
       
@@ -94,8 +94,8 @@ module.exports = (pool) => {
       const hireDate = new Date().toISOString().split('T')[0]; // Current date
       
       const [result] = await pool.query(
-        'INSERT INTO staff (Name, Role, SSN, Birthdate, Sex, Address, HireDate, SupervisorID, Username, Password) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-        [name, role, ssn, birthdate, sex, address, hireDate, supervisorID, username, hashedPassword]
+        'INSERT INTO staff (Name, Role, SSN, Birthdate, Sex, Address, HireDate, SupervisorID, Username, Password, StaffType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [name, role, ssn, birthdate, sex, address, hireDate, supervisorID, username, hashedPassword, stafftype]
       );
       
       res.status(201).json({ 

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -119,6 +119,8 @@ const Dashboard = () => {
           color: 'bg-pink-600'
         }
       ],
+    };
+    const staffTypeModules = {
       'Zookeeper': [
         {
           title: 'Assigned Enclosures',
@@ -172,7 +174,9 @@ const Dashboard = () => {
     // Get modules specific to the user's role
     const userRoleModules = roleSpecificModules[currentUser.staffRole] || [];
 
-    return [...commonModules, ...userRoleModules];
+    const userTypeModules = staffTypeModules[currentUser.staffType] || [];
+
+    return [...commonModules, ...userRoleModules, ...userTypeModules];
   };
 
   if (!currentUser || currentUser.role !== 'staff') {


### PR DESCRIPTION
I noticed that the staff type components couldn't be seen in the staff dashboards.

Zookeepers: Assigned Enclosures, Animals
Vet: Health Monitoring, Medical Records
Gift Shop Clerk: Inventory Management, Sales

Now, these components can be found in the appropriate user staff type account.